### PR TITLE
Don't Error when sendto() errors with ENETUNREACH or EHOSTUNREACH

### DIFF
--- a/src/util/utils.cpp
+++ b/src/util/utils.cpp
@@ -106,8 +106,6 @@ void Socket::sendto(const osiSockAddr& dest, const char* buf, size_t buflen) con
     ssize_t ret = ::sendto(sock, buf, buflen, 0, &dest.sa, sizeof(dest));
     if(ret<0) {
         int code = SOCKERRNO;
-        if(code==SOCK_EWOULDBLOCK)
-            throw SocketBusy();
         throw SocketError(code);
     } else if(size_t(ret)!=buflen)
         throw std::runtime_error("Incomplete sendto()");
@@ -119,8 +117,6 @@ size_t Socket::recvfrom(osiSockAddr& src, char* buf, size_t buflen) const
     ssize_t ret = ::recvfrom(sock, buf, buflen, 0, &src.sa, &len);
     if(ret<0) {
         int code = SOCKERRNO;
-        if(code==SOCK_EWOULDBLOCK)
-            throw SocketBusy();
         throw SocketError(code);
     }
     return size_t(ret);

--- a/src/util/utils.h
+++ b/src/util/utils.h
@@ -59,12 +59,6 @@ struct epicsShareClass SocketError : public std::exception
     const char *what() const throw();
 };
 
-struct epicsShareClass SocketBusy : public SocketError
-{
-    SocketBusy() :SocketError(SOCK_EWOULDBLOCK) {}
-    virtual ~SocketBusy() throw() {}
-};
-
 // RAII handle to ensure that sockets aren't leaked
 // and helper to make socket calls throw SocketError
 struct Socket


### PR DESCRIPTION
Don't latch for transient TX errors.  eg. routing change, or when NIC unplugged.

Eliminate SocketBusy since SOCK_EWOULDBLOCK is no longer quite such a special case.

@shoobler @dchabot fyi.
